### PR TITLE
assign gene names for vague subunit designations

### DIFF
--- a/DataParse.Rmd
+++ b/DataParse.Rmd
@@ -171,6 +171,16 @@ for (i in seq(length(fasta))) {
     rawpro=paste(str_extract_all(gb,pro_pattern)[[1]],collapse="")
     rawgenpro=paste(rawgen,rawpro,collapse = "")
     
+    #check rawgenpro for vague "subunit" designations
+    if(str_detect(gb,"mitochondrial")){
+      if(str_detect(rawgenpro,"large subunit")){rawgenpro=paste(rawgenpro,"16S",sep=" ")}
+      #if(str_detect(rawgenpro,"small subunit")){} #not needed as all are labeled 16S
+    }else{
+      if(str_detect(rawgenpro,"small subunit")){rawgenpro=paste(rawgenpro,"18S",sep="")}
+      if(str_detect(rawgenpro,"large subunit")){} #not needed as all are labeled 28S
+    }
+
+    #if no info in "gene" or "product", check for "note":
     if(str_length(rawgenpro)<2){
       note_pattern="note=\"[^\"]+\""
       rawnote=paste(str_extract_all(gb,note_pattern)[[1]],collapse="")


### PR DESCRIPTION
assign gene names for vague subunit designations.
Notes:
### 10/30/16 - Dealing with vague "subunit" gene names

12S mitochondrial
-----12S ribosomal RNA (not listed as small in Amphipoda/Isopoda filtered)
16S mitochondrial
-----small subunit ribosomal, organelle = mitochondrion
-----large subunit ribosomal, organelle = mitochondrion
18S small nuclear
-----18S small subunit ribosomal (no mitochondrial, mitochondrion)
28S large nuclear
-----large subunit ribosomal (no mitochondiral, mitochondrion)
-----not listed w/o "28S" in filtered Amphipoda/Isopoda

"small subunit" mitochondrial - always listed as 16S
"small subunit" NOT mitochondrial - sometimes listed as 18S, never as 16S, sometimes not specified

pseudocode plan:
-if gb contains "mitochondrial":
-----if gene or product contains "large subunit" - add 16S to raw gene name (sometimes listed as 16S, never listed as anything else, randomly selected unlisted ones blast to 16S)
-----if gene or product contains "small subunit" - not necessary! (all listed as 16S, never listed as 12S or anything else)
-if gb does not contain "mitochondrial":
-----if gene or product contains "large subunit" - not necessary! (all listed as 28S, never listed as anything else)
-----if gene or product contains "small subunit" - add 18S to raw gene name (sometimes listed as 18S, never listed as anything else, randomly selected unlisted ones blast to 18S)

before starting vague_subunit_names:
485 "others" including 150 listing "subunit". Examples:
KR061668.1 - mitochondrial, organelle="mitochondrion, product="large subunit ribosomal RNA" (now listed as 16S)
GQ302703.1 - (not mitochondrial), product="small subunit ribosomal RNA" (now listed as 18S)
AB295402.1 - (not mitochondrial), product="small subunit ribosomal RNA" (now listed as 18S)
AY048175.1 - (not mitochondrial), product="small subunit ribosomal RNA" (now listed as 18S)
KP316253.1 - mitochondrial, organelle="mitochondrion, product="large subunit ribosomal RNA" (now listed as 16S)
AY781426.1 - (not mitochondrial), product="small subunit ribosomal RNA" (now listed as 18S)

after starting vague_subunit_names:
335 "others", none of which list "subunit"
